### PR TITLE
Set BASH as execution shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Usage
 
 ```
-sh covid19-cli.sh -h
+bash covid19-cli.sh -h
 ```
 
 Or if you prefer to make it executable:

--- a/covid19-cli.sh
+++ b/covid19-cli.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Corona Virus (Covid-19) statistics cli,
 #


### PR DESCRIPTION
This sets `bash` as execution shell. 
Script is not compatible with `zsh` or `dash` (default `/bin/sh` link for Ubuntu/Debian). Bash is listed as a dependency