### PR TITLE
Reset the terminal original color (instead of using white)

### DIFF
--- a/covid19-cli.sh
+++ b/covid19-cli.sh
@@ -178,8 +178,8 @@ normal=$(tput sgr0)
 
 # colours
 green=$(tput setaf 2)
+no_color='\033[0m'
 red=$(tput setaf 1)
-white=$(tput setaf 7)
 yellow=$(tput setaf 3)
 
 # Notify on function success
@@ -338,9 +338,9 @@ main() {
     recoveredHistorical=$(echo $historicalResult | jq -r '.timeline .recovered | map(.|tostring) | join(",")')
 
     printf "\n"
-    printf "${bold}Cases:\t\t${normal}${yellow}${cases}\t$(spark ${casesHistorical})${white}\n"
-    printf "${bold}Deaths:\t\t${normal}${red}${deaths}\t$(spark ${deathsHistorical})${white}\n"
-    printf "${bold}Recovered:\t${normal}${green}${recovered}\t$(spark ${recoveredHistorical})${white}\n"
+    printf "${bold}Cases:\t\t${normal}${yellow}${cases}\t$(spark ${casesHistorical})${no_color}\n"
+    printf "${bold}Deaths:\t\t${normal}${red}${deaths}\t$(spark ${deathsHistorical})${no_color}\n"
+    printf "${bold}Recovered:\t${normal}${green}${recovered}\t$(spark ${recoveredHistorical})${no_color}\n"
 
   else
     success "Global Statistics"
@@ -350,9 +350,9 @@ main() {
     recovered=$(echo $result | jq ".recovered")
 
     printf "\n"
-    printf "${bold}Cases:\t\t${normal}${yellow}${cases}${white}\n"
-    printf "${bold}Deaths:\t\t${normal}${red}${deaths}${white}\n"
-    printf "${bold}Recovered:\t${normal}${green}${recovered}${white}\n"
+    printf "${bold}Cases:\t\t${normal}${yellow}${cases}${no_color}\n"
+    printf "${bold}Deaths:\t\t${normal}${red}${deaths}${no_color}\n"
+    printf "${bold}Recovered:\t${normal}${green}${recovered}${no_color}\n"
   fi;
 
 }


### PR DESCRIPTION
Correctly reset the terminal used color (instead of using white as the default)
before
<img width="580" alt="Screenshot 2020-03-22 at 23 01 09" src="https://user-images.githubusercontent.com/347712/77261832-ce92b400-6c91-11ea-98ae-17e419327b1b.png">
after
<img width="646" alt="Screenshot 2020-03-22 at 23 01 47" src="https://user-images.githubusercontent.com/347712/77261843-e0745700-6c91-11ea-8c77-3059b798c39e.png">

